### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/Auth/PAM/Simple.pm6
+++ b/lib/Auth/PAM/Simple.pm6
@@ -1,4 +1,4 @@
-module Auth::PAM::Simple;
+unit module Auth::PAM::Simple;
 
 our sub authenticate($service, Str $user, Str $pass --> Bool) is export {
     return !auth($service, $user, $pass);


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.